### PR TITLE
Module: Overlay wrapper into place instead of adding it manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,9 @@ I mean, it wasn't like [upstream was gonna stop bikeshedding](https://github.com
 - Q: That sucks.
 - A: True.
 - Q: Do I need to have the nixpkgs flatpak service enabled too for flatpak to work?
-- A: You probably shouldn't.
-- Q: What happens if I do?
+- A: Very likely.
+- Q: What happens if I don't?
 - A: Um... bad things, probably. I don't think I've tried it.
-- Q: Why not use an overlay instead?
-- A: That's a good question, actually.
-- Q: And what's the answer?
-- A: I dunno.
-- Q: Are you being serious?
-- A: Yes. ^w^
-- Q: Why are you like this?
-- A: I'm really busy.
 - Q: Do you accept PRs?
 - A: Sure. :3
 - Q: Why did you give it such a bad/awkward name?
@@ -32,6 +24,8 @@ I mean, it wasn't like [upstream was gonna stop bikeshedding](https://github.com
 - A: I like 🦀 uwu
 - Q: What?
 - A: Yes.
+- Q: uwu
+- A: :3
 
 
 ## Features 

--- a/pkg.nix
+++ b/pkg.nix
@@ -18,12 +18,15 @@ in
 (pkgs.symlinkJoin {
     name = "flatpak";
     meta.mainProgram = "flatpak";
-    paths = [ pkgs.flatpak rustPkg ];
+    paths = [ flatpak-pkg rustPkg ];
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postBuild = ''
       mv "$out/bin/flatpak" "$out/bin/flatpak-raw"
       ln -s "$out/bin/nixpak-flatpak-wrapper" "$out/bin/flatpak"
     '';
+    passthru = {
+      inherit (flatpak-pkg) icon-validator-patch;
+    };
   })
 
 


### PR DESCRIPTION
This pull request makes the module overlay the flatpak binary with the wrapper instead of manually adding it to systemd packages, etc.

This makes enabling the module compatible with `services.flatpak.enable = true;`