### PR TITLE
Module: Use services.flatpak.package to override binary 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,8 @@ I mean, it wasn't like [upstream was gonna stop bikeshedding](https://github.com
 - A: Yeah.
 - Q: That sucks.
 - A: True.
-- Q: Do I need to have the nixpkgs flatpak service enabled too for flatpak to work?
-- A: Yes.
-- Q: What happens if I do?
-- A: Um... bad things, probably. I don't think I've tried it.
-- Q: Why not use an overlay instead?
-- A: That triggers a bunch of rebuilds that error.
+- Q: Do I need to have the nixpkgs flatpak service enabled as well for flatpak to work?
+- A: Yep. :)
 - Q: Do you accept PRs?
 - A: Sure. :3
 - Q: Why did you give it such a bad/awkward name?

--- a/README.md
+++ b/README.md
@@ -13,17 +13,11 @@ I mean, it wasn't like [upstream was gonna stop bikeshedding](https://github.com
 - Q: That sucks.
 - A: True.
 - Q: Do I need to have the nixpkgs flatpak service enabled too for flatpak to work?
-- A: You probably shouldn't.
+- A: Yes.
 - Q: What happens if I do?
 - A: Um... bad things, probably. I don't think I've tried it.
 - Q: Why not use an overlay instead?
-- A: That's a good question, actually.
-- Q: And what's the answer?
-- A: I dunno.
-- Q: Are you being serious?
-- A: Yes. ^w^
-- Q: Why are you like this?
-- A: I'm really busy.
+- A: That triggers a bunch of rebuilds that error.
 - Q: Do you accept PRs?
 - A: Sure. :3
 - Q: Why did you give it such a bad/awkward name?
@@ -32,6 +26,8 @@ I mean, it wasn't like [upstream was gonna stop bikeshedding](https://github.com
 - A: I like 🦀 uwu
 - Q: What?
 - A: Yes.
+- Q: uwu
+- A: :3
 
 
 ## Features 
@@ -59,6 +55,8 @@ nixpak-flatpak-wrapper = {
 
 Once you've added the `nixosModules.default` to your system modules, configuration can happen like so:
 ```nix
+services.flatpak.enable = true;
+
 programs.nixpak-flatpak-wrapper = {
   enable = true;
   settings = {

--- a/module.nix
+++ b/module.nix
@@ -59,11 +59,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [
-      wrapperPackage
-    ];
-    services.dbus.packages = [ wrapperPackage ];
-    systemd.packages = [ wrapperPackage ];
+    services.flatpak.package = wrapperPackage;
 
     environment.etc."nixpak-flatpak-wrapper.toml".source = fmt.generate "nixpak-flatpak-wrapper.toml" cfg.settings;
   };

--- a/pkg.nix
+++ b/pkg.nix
@@ -18,7 +18,7 @@ in
 (pkgs.symlinkJoin {
     name = "flatpak";
     meta.mainProgram = "flatpak";
-    paths = [ pkgs.flatpak rustPkg ];
+    paths = [ flatpak-pkg rustPkg ];
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postBuild = ''
       mv "$out/bin/flatpak" "$out/bin/flatpak-raw"


### PR DESCRIPTION
Instead of adding the wrapper package to `environment.systemPackages` and the likes ourselves, we now use the `services.flatpak.package` option.

Depends on https://github.com/NixOS/nixpkgs/pull/331993
Supercedes #4